### PR TITLE
Arreglo de lista citas

### DIFF
--- a/SSCEntrega3-war/web/info_cita.xhtml
+++ b/SSCEntrega3-war/web/info_cita.xhtml
@@ -52,12 +52,7 @@
                             </p:dataTable>
                         </td>
                     </tr>
-                    <tr>
-                        <td><br> </br>
-                            <h:link id="atras" value="Atrás" outcome="nueva_cita.xhtml" />
-                             
-                        </td>
-                    </tr>
+                   
                 </table>
 
                 </p:scrollPanel>  

--- a/SSCEntrega3-war/web/lista_citas.xhtml
+++ b/SSCEntrega3-war/web/lista_citas.xhtml
@@ -48,7 +48,7 @@
                     </p:column>
                     <p:column id="verCita" headerText="Ver cita">
                        <h:commandButton id="btn-ver-cita" value="Ver cita" 
-                                        class="btn btn-info" action="#{ctrListaCita.verCita(cita.id)}"/>
+                                        class="btn btn-info" action="#{controladorCita.browsePage(cita.id)}"/>
 
                     </p:column>   
                    <p:column id="eliminar" headerText="Eliminar">


### PR DESCRIPTION
El problema era que en la vista lista_citas no se llamaba al controlador adecuado mediante browsePage, y no se cargaban los datos. Solucionado.

Además, me he cargado el botón de "atrás". Lo añadí pensando en una cosa pero al final se acabó usando para otra. Es un problema porque se puede ir a info_citas desde tres sitios distintos, y al darle a "atrás" sólo te llevaba a crear_cita. Si queremos navegabilidad ya más adelante pondremos botones para ir a cada lugar, pero de momento es feo (y como soy su padre pues decido destruirlo).

Fixes #50 
